### PR TITLE
Force C locale for the entire script

### DIFF
--- a/plasmac.scpost
+++ b/plasmac.scpost
@@ -20,6 +20,7 @@ noArcs      = 0 -- set to 1 to convert arcs to line segments
 
 revNum  = 'F'
 revDate = 'May 15 2020'
+assert(os.setlocale('C'))
 
 if cParms == 1 then
     post.DefineCustomToolParam('PlasmaTool', 'Puddle jump height', 'pjHeight', sc.unit1DECPLACE, 0, 0, 200)


### PR DESCRIPTION
This has the advantage that it doesn't matter anymore which locale the
users OS has. This fixes issues where the delimiter in numbers is
sometimes a comma and otherwise a point.